### PR TITLE
Add rustic-mode with rust-mode as a parent

### DIFF
--- a/snippets/rustic-mode/.yas-parents
+++ b/snippets/rustic-mode/.yas-parents
@@ -1,0 +1,1 @@
+rust-mode


### PR DESCRIPTION
This should fix Rust snippets in doom-emacs.