### PR TITLE
Corrected data type in [fn] snippet

### DIFF
--- a/rust-mode/fn
+++ b/rust-mode/fn
@@ -4,6 +4,6 @@
 # uuid: fn
 # condition: (doom-snippets-bolp)
 # --
-fn ${1:function_name}($2) ${3:-> ${4:int} }{
+fn ${1:function_name}($2) ${3:-> ${4:i32} }{
    `%`$0
 }


### PR DESCRIPTION
Default data type is i32,  int does not exist in Rust Language.