### PR TITLE
Use user-full-name for snippet vars

### DIFF
--- a/snippet-mode/vars
+++ b/snippet-mode/vars
@@ -4,8 +4,8 @@
 # uuid: #
 # --
 # -*- mode: snippet -*-
-# name: $1
-# contributor: ${2:`(user-full-name)`}
+${1:# contributor: `(user-full-name)`
+}# name: $2
 # key: ${3:trigger-key}${4:
 # condition: t}
 # --

--- a/snippet-mode/vars
+++ b/snippet-mode/vars
@@ -5,7 +5,8 @@
 # --
 # -*- mode: snippet -*-
 # name: $1
-# key: ${2:trigger-key}${3:
+# contributor: ${2:`(user-full-name)`}
+# key: ${3:trigger-key}${4:
 # condition: t}
 # --
 $0


### PR DESCRIPTION
## Description

Use `user-full-name` as the default value of snippet author, which is defined in Doom Emacs configuration.