### PR TITLE
LaTeX theorem environments

### DIFF
--- a/latex-mode/axiom
+++ b/latex-mode/axiom
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: axiom
+# key: axm
+# group: theorems
+# --
+\begin{axiom}
+`%`$0
+\end{axiom}

--- a/latex-mode/begin
+++ b/latex-mode/begin
@@ -4,5 +4,5 @@
 # uuid: begin
 # --
 \begin{${1:environment}}
-$0
+`%`$0
 \end{$1}

--- a/latex-mode/corollary
+++ b/latex-mode/corollary
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: corollary
+# key: clr
+# group: theorems
+# --
+\begin{corollary}
+`%`$0
+\end{corollary}

--- a/latex-mode/definition
+++ b/latex-mode/definition
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: definition
+# key: def
+# group: theorems
+# --
+\begin{definition}
+`%`$0
+\end{definition}

--- a/latex-mode/exercise
+++ b/latex-mode/exercise
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: exercise
+# key: exc
+# group: theorems
+# --
+\begin{exercise}
+`%`$0
+\end{exercise}

--- a/latex-mode/lemma
+++ b/latex-mode/lemma
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: lemma
+# key: lmm
+# group: theorems
+# --
+\begin{lemma}
+`%`$0
+\end{lemma}

--- a/latex-mode/proof
+++ b/latex-mode/proof
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: proof
+# key: prf
+# group: theorems
+# --
+\begin{proof}
+`%`$0
+\end{proof}

--- a/latex-mode/remark
+++ b/latex-mode/remark
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: remark
+# key: rmk
+# group: theorems
+# --
+\begin{remark}
+`%`$0
+\end{remark}

--- a/latex-mode/theorem
+++ b/latex-mode/theorem
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: theorem
+# key: thm
+# group: theorems
+# --
+\begin{theorem}
+`%`$0
+\end{theorem}


### PR DESCRIPTION
This adds LaTeX snippets for theorem environments. 

The theorem environments are user-defined (not built in latex),but I feel that
these names are common enough to be in doom-themes - and if not, you can always
define new ones yourself. I gave them the 'theorems' group to differentiate them from the rest.