### PR TITLE
Add 'at first line' condition to "mode" snippet

### DIFF
--- a/fundamental-mode/mode
+++ b/fundamental-mode/mode
@@ -2,5 +2,6 @@
 # name: mode
 # key: mode
 # uuid: mode
+# condition: (= (line-number-at-pos) 1)
 # --
 `comment-start`-*- mode: ${1:mode} -*-`comment-end`


### PR DESCRIPTION
I accidentally trigger the `mode` snippet quite a lot, while pressing TAB after a function
that ends with "mode" (of which there are a lot). 

This PR should fix that, and wouldn't change how you use
the snippet because it should be only inserted on the first line anyway.