### PR TITLE
Generalize user and email on org/head template

### DIFF
--- a/org-mode/head
+++ b/org-mode/head
@@ -4,5 +4,5 @@
 # uuid: head
 # --
 #+TITLE:     ${1:Untitled Document}
-#+AUTHOR:    Henrik Lissner
-#+EMAIL:     henrik@lissner.net
+#+AUTHOR:    ${2:`user-full-name`}
+#+EMAIL:     ${3:`user-mail-address`}


### PR DESCRIPTION
Small fix, snippet creator name and mail was hard-coded.
Change to use the commonly personalized user variables