### PR TITLE
Add in-math condition to short-key latex snippets

### DIFF
--- a/latex-mode/capgls
+++ b/latex-mode/capgls
@@ -2,5 +2,6 @@
 # name: Gls
 # key: G
 # uuid: G
+# condition: (not (save-restriction (widen) (texmathp)))
 # --
 \Gls{${1:label}}

--- a/latex-mode/cite
+++ b/latex-mode/cite
@@ -2,5 +2,6 @@
 # name: cite
 # key: c
 # uuid: c
+# condition: (not (save-restriction (widen) (texmathp)))
 # --
 \cite{$1} $0

--- a/latex-mode/emph
+++ b/latex-mode/emph
@@ -2,5 +2,6 @@
 # name: emph
 # key: e
 # uuid: e
+# condition: (not (save-restriction (widen) (texmathp)))
 # --
 \emph{${1:`%`}}$0

--- a/latex-mode/gls
+++ b/latex-mode/gls
@@ -2,5 +2,6 @@
 # name: gls
 # key: g
 # uuid: g
+# condition: (not (save-restriction (widen) (texmathp)))
 # --
 \gls{${1:label}}

--- a/latex-mode/item
+++ b/latex-mode/item
@@ -2,5 +2,6 @@
 # name: item
 # key: -
 # uuid: -
+# condition: (not (save-restriction (widen) (texmathp)))
 # --
 \item ${0:`%`}

--- a/latex-mode/question
+++ b/latex-mode/question
@@ -2,5 +2,6 @@
 # name: question
 # key: q
 # uuid: q
+# condition: (not (save-restriction (widen) (texmathp)))
 # --
 \question{${0:`%`}}

--- a/latex-mode/textbf
+++ b/latex-mode/textbf
@@ -2,5 +2,6 @@
 # name: textbf
 # key: b
 # uuid: b
+# condition: (not (save-restriction (widen) (texmathp)))
 # --
 \textbf{`%`$1}$0


### PR DESCRIPTION
Finally figured out what caused the nested snippet condition issue!

This adds 
``` emacs-lisp
(save-restriction (widen) (texmathp))
```
to all short-key latex snippets, to prevent their accidental expansion when using nested snippets in LaTeX math-mode.

Closes #22, until joaotavora/yasnippet/issues/1047 is fixed: then I'll remove the `(save-restriction (widen))`.