### PR TITLE
Fix buffer mutation in C++ access modifiers.

### DIFF
--- a/c++-mode/private
+++ b/c++-mode/private
@@ -1,5 +1,6 @@
 # -*- mode: snippet -*-
 # name: private
+# expand-env: ((yas-also-auto-indent-first-line t))
 # --
-private:`(progn (indent-according-to-mode) "")`
+private:
     $0

--- a/c++-mode/protected
+++ b/c++-mode/protected
@@ -1,5 +1,6 @@
 # -*- mode: snippet -*-
 # name: protected
+# expand-env: ((yas-also-auto-indent-first-line t))
 # --
-protected:`(progn (indent-according-to-mode) "")`
+protected:
     $0

--- a/c++-mode/public
+++ b/c++-mode/public
@@ -1,5 +1,6 @@
 # -*- mode: snippet -*-
 # name: public
+# expand-env: ((yas-also-auto-indent-first-line t))
 # --
-public:`(progn (indent-according-to-mode) "")`
+public:
     $0


### PR DESCRIPTION
This PR replaces the calls to `indent-according-to-mode` in the snippets for the C++ access modifiers with the `expand-env` property. This causes the snippets to no longer mutate the buffer and fixes the corresponding warning from Yasnippet.