### PR TITLE
Correct y-or-n-p snippet

### DIFF
--- a/emacs-lisp-mode/y-or-n-p
+++ b/emacs-lisp-mode/y-or-n-p
@@ -3,4 +3,4 @@
 # key: yn
 # uuid: yn
 # --
-(`(symbol-function 'yes-or-no-p)` "$1")
+(yes-or-no-p "$1")


### PR DESCRIPTION
This should be a correction for the Issue: Error on +snippet/edit #4127
I tried to reason about, what was the symbol-function should have achieved, but i could not find one. I would either love to find out about the reason or ask you to accept my pull request.