### PR TITLE
{ in the next line for psr-2 and psr-12 coding standard adherence

### DIFF
--- a/php-mode/abstract-class
+++ b/php-mode/abstract-class
@@ -3,6 +3,7 @@
 # key: acl
 # uuid: acl
 # --
-abstract class ${1:Name}${2: extends ${3:Parent}} {
+abstract class ${1:Name}${2: extends ${3:Parent}}
+{
     `%`$0
 }

--- a/php-mode/class
+++ b/php-mode/class
@@ -3,6 +3,7 @@
 # key: cl
 # uuid: cl
 # --
-class ${1:Name}${2: extends ${3:Parent}} {
+class ${1:Name}${2: extends ${3:Parent}}
+{
     `%`$0
 }

--- a/php-mode/method
+++ b/php-mode/method
@@ -3,6 +3,7 @@
 # key: met
 # uuid: met
 # --
-${1:public} function ${2:name}($3) {
+${1:public} function ${2:name}($3)
+{
     `%`$0
 }


### PR DESCRIPTION
Hello Doom maintainers,

Several years ago, the [PHP-FIG](https://www.php-fig.org/) introduced several standards in the PHP world. Some of them are related to coding standard ([PSR-2](https://www.php-fig.org/psr/psr-2/) and [PSR-12](https://www.php-fig.org/psr/psr-12/)).

The stardards are widely adopted for [many major projects in the website](https://www.php-fig.org/personnel/#member-projects), including big ones not listed there, such as Symfony and Laravel.

I'd love you to merge it in the `php-mode` snippets.

**Detailed references:**

- https://www.php-fig.org/psr/psr-2/#11-example
- https://www.php-fig.org/psr/psr-2/#45-abstract-final-and-static
- https://www.php-fig.org/psr/psr-2/#43-methods