### PR TITLE
Improve Rails Snippets

### DIFF
--- a/rspec-mode/cont
+++ b/rspec-mode/cont
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
-# name: context "modifier" do ... end
+# name: context 'modifier' do ... end
 # --
-context "${1:modifier}" do
+context \'${1:modifier}\' do
   $0
 end

--- a/rspec-mode/context
+++ b/rspec-mode/context
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
-# name: context "modifier" do ... end
+# name: context 'modifier' do ... end
 # --
-context "${1:modifier}" do
+context \'${1:modifier}\' do
   $0
 end

--- a/rspec-mode/desc
+++ b/rspec-mode/desc
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
 # name: describe Class do ... end
 # --
-describe "${1:modifier}" do
+describe \'${1:modifier}\' do
   $0
 end

--- a/rspec-mode/describe
+++ b/rspec-mode/describe
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
 # name: describe Class do ... end
-# expand-env: ((top-level (rspec-top-level-desc-p)) (maybe-quote (unless top-level "\"")))
+# expand-env: ((top-level (rspec-top-level-desc-p)) (maybe-quote (unless top-level "\'")))
 # --
 describe `maybe-quote`${1:`(and top-level (rspec-class-from-file-name))`}`maybe-quote` do
   $0

--- a/rspec-mode/describem
+++ b/rspec-mode/describem
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
-# name: describe Class, "modifier" do ... end
+# name: describe Class, 'modifier' do ... end
 # --
-describe ${1:`(rspec-class-from-file-name)`}, "${2:modifier}" do
+describe ${1:`(rspec-class-from-file-name)`}, \'${2:modifier}\' do
   $0
 end

--- a/rspec-mode/feature
+++ b/rspec-mode/feature
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
-# name: feature "description" do ... end
+# name: feature 'description' do ... end
 # --
-feature "${1:description}" do
+feature \'${1:description}\' do
   $0
 end

--- a/rspec-mode/it
+++ b/rspec-mode/it
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
-# name: it "does something" do ... end
+# name: it 'does something' do ... end
 # --
-it "${1:does something}" do
+it \'${1:does something}\' do
   $0
 end

--- a/rspec-mode/scn
+++ b/rspec-mode/scn
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
-# name: scenario "does something" do ... end
+# name: scenario 'does something' do ... end
 # --
-scenario "${1:does something}" do
+scenario \'${1:does something}\' do
   $0
 end


### PR DESCRIPTION
The ruby pattern is use single quotes instead of double quotes for strings.