### PR TITLE
Create chinese_dollar in org mode

### DIFF
--- a/org-mode/chinese_dollar
+++ b/org-mode/chinese_dollar
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: Chinese$
+# uuid: ￥￥
+# key: ￥￥
+# expand-env: ((yas-wrap-around-region (fcitx--deactivate)) (yas-after-exit-snippet-hook (lambda () (fcitx--activate))))
+# condition: t
+# --
+\$$1\$ $0

--- a/org-mode/chinese_link
+++ b/org-mode/chinese_link
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: chinese【
+# uuid: 【【
+# key: 【【
+# expand-env: ((yas-wrap-around-region (fcitx--deactivate)) (yas-after-exit-snippet-hook (lambda () (fcitx--activate))))
+# condition: t
+# --
+[[$0]]


### PR DESCRIPTION
It is useful when you write document in Chinese and write formulas at same time.

￥￥ is the Chinese character of $$。

press `$$` when fcitx on its input is `￥￥` 
tab in to snippet, turn fcitx off
enter formula in ASCII
tab to $0, exit snippet, turn fcitx on

Some points might to fix:
1. To me, for ￥ is a Chinese character can only be entered by fcitx, it is O.K. to assume the environment provides fcitx before entering the snippet. It would not be triggered by other Language users, so it is safe. But for other Chinese users, other methods can be used. How to handle these situations.
2. bind `fcitx--deactivate` with  `yas-wrap-around-region` is a little strange. Any other better way?
