### PR TITLE
`bang` snippet only on first line

### DIFF
--- a/fundamental-mode/bang
+++ b/fundamental-mode/bang
@@ -2,6 +2,7 @@
 # name: bang
 # key: #!
 # uuid: #!
+# condition: (eq 1 (line-number-at-pos))
 # insert a choice if you have more than one possibility
 # --
 #!/usr/bin/env ${1:bash}


### PR DESCRIPTION
Prevent `bang` (`#!`) fundamental mode snippet from activating when not on line 1. Solves #71.