### PR TITLE
rust-mode: add common async functions

### DIFF
--- a/rust-mode/async_fn
+++ b/rust-mode/async_fn
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# name: async function
+# key: afn
+# uuid: afn
+# condition: (doom-snippets-bolp)
+# --
+async fn ${1:function_name}($2) ${3:-> ${4:i32} }{
+   `%`$0
+}

--- a/rust-mode/pub_async_fn
+++ b/rust-mode/pub_async_fn
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# name: public async function
+# key: pafn
+# uuid: pafn
+# condition: (doom-snippets-bolp)
+# --
+pub async fn ${1:function_name}($2) ${3:-> ${4:i32} }{
+   `%`$0
+}


### PR DESCRIPTION
# Add common async functions

As `async fn` normally would return a Result, this is a bit different from `fn`s

![image](https://user-images.githubusercontent.com/14071051/143175752-6aacb458-852d-4f97-bb4a-eec29a5628ec.png)
